### PR TITLE
Fix Lofi text selection color

### DIFF
--- a/src/styles/screenplay.css
+++ b/src/styles/screenplay.css
@@ -15,9 +15,17 @@
   --screenplay-selection-background: color-mix(in oklch, var(--color-primary) 30%, transparent);
 }
 
+:root[data-theme='lofi'],
+:root[data-theme='black'] {
+  --screenplay-selection-color: rgb(255 255 255);
+}
+
 :root[data-theme='lofi'] {
   --screenplay-selection-background: rgb(107 114 128 / 0.85);
-  --screenplay-selection-color: rgb(255 255 255);
+}
+
+:root[data-theme='black'] {
+  --screenplay-selection-background: rgb(75 85 99 / 0.9);
 }
 
 /* Paginated Editor Container */

--- a/src/styles/screenplay.css
+++ b/src/styles/screenplay.css
@@ -12,6 +12,12 @@
   --page-margin-right: 1in;
   --page-content-height: calc(var(--page-height) - var(--page-margin-top) - var(--page-margin-bottom));
   --page-gap: 40px;
+  --screenplay-selection-background: color-mix(in oklch, var(--color-primary) 30%, transparent);
+}
+
+:root[data-theme='lofi'] {
+  --screenplay-selection-background: rgb(107 114 128 / 0.85);
+  --screenplay-selection-color: rgb(255 255 255);
 }
 
 /* Paginated Editor Container */
@@ -328,11 +334,14 @@
 
 /* Selection styling */
 .screenplay-editor ::selection {
-  @apply bg-primary/30;
+  color: var(--screenplay-selection-color, inherit);
+  background-color: var(--screenplay-selection-background);
 }
 
 .inactive-editor-selection {
-  @apply bg-primary/30 rounded-[2px];
+  color: var(--screenplay-selection-color, inherit);
+  background-color: var(--screenplay-selection-background);
+  @apply rounded-[2px];
 }
 
 /* Element type indicator */


### PR DESCRIPTION
## Summary
- add a shared screenplay selection background token
- override the Lofi theme selection to use gray with white selected text
- override the Black theme selection to use lighter gray with white selected text
- keep active and inactive editor selection styling in sync

## Test
- npm run build